### PR TITLE
Support device-tree enabled kernel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+micro-evtd (3.4-3) UNRELEASED; urgency=medium
+
+  * Support device-tree enabled kernel
+
+ -- Roger Shimizu <rogershimizu@gmail.com>  Sun, 31 Jan 2016 00:20:21 +0900
+
 micro-evtd (3.4-2) unstable; urgency=low
 
   * debian/udeb/micro-evtd.command: Fixed bashisms. Thanks to Martin Michlmayr

--- a/debian/micro-evtd.init
+++ b/debian/micro-evtd.init
@@ -70,6 +70,12 @@ check_supported_device() {
 	# Check if current platform is supported.
 	device=$(sed -n '/Hardware/ {s/^.*: //;p}' /proc/cpuinfo)
 	case $device in
+		*"(Flattened Device Tree)")
+		device=$(cat /proc/device-tree/model)
+		;;
+	esac
+
+	case $device in
 		# Supported hardware, start the process using the wrapper
 		"Buffalo Linkstation Pro/Live" | "Buffalo/Revogear Kurobox Pro")
 		return 0
@@ -79,7 +85,7 @@ check_supported_device() {
 		log_failure_msg "micro-evtd error: device is not supported"
 		exit 1
 		;;
-esac
+	esac
 }
 
 start_server() {


### PR DESCRIPTION
Dear micro-evtd maintainer,

As you know, Buffalo Linkstation Pro/Live will be have device tree support in kernel 4.6 [0].
So it's necessary to support device tree enabled kernel for micro-evtd side.

[0]: http://lists.infradead.org/pipermail/linux-arm-kernel/2016-February/405948.html

Thank you!

Roger