### PR TITLE
Support device-tree enabled kernel for udeb script

### DIFF
--- a/debian/udeb/micro-evtd.command
+++ b/debian/udeb/micro-evtd.command
@@ -23,6 +23,11 @@ micro_evtd_start() {
 # Test if device is supported
 machine=`sed -n '/Hardware/ {s/^Hardware\s*:\s//;p}' /proc/cpuinfo`
 case $machine in
+	*"(Flattened Device Tree)")
+	machine=$(cat /proc/device-tree/model)
+	;;
+esac
+case $machine in
 	"Buffalo Linkstation Pro/Live" | "Buffalo/Revogear Kurobox Pro")
 	# Success or continue
 	[ "$1" = "-t" ] && exit 0 || true ;;


### PR DESCRIPTION
Thanks for your remind!
Here's the patch to apply the same logic for udeb script.