### PR TITLE
Match default temprature configuration with the value in the config file

### DIFF
--- a/src/micro-evtd.c
+++ b/src/micro-evtd.c
@@ -113,7 +113,7 @@ TIMER* ponTimer=NULL;
 char* pDelayProcesses = NULL;
 int last_day;
 char i_debug=0;
-int iTempRange[4]={30, 37, 40, 60};
+int iTempRange[4]={35, 45, 50, 60};
 int fanFaultSeize=30;
 char iControlFan=1;
 int refreshRate=40;


### PR DESCRIPTION
Default temprature configuration that really used is different from the configuration written in a sample config file.

The configuration file (files/micro-evtd.conf) says:

>  # Default 35 45 50 60, temperature/fan controls
>  # 35 - slow, normal running ~33 C-deg
>  # 45 - fast
>  # 50 - full
>  # 60 - Too hot alarm, overheat
>  # TEMP-RANGE=35 45 50 60

But the value really used is here (src/micro-evtd.c):

> int iTempRange[4]={30, 37, 40, 60};`

This difference annoys users. I think both values are correct itself, but this pull request uses the value in config file because my box indicates 40-41 degrees everytime (fan speed is always "full" with the values written in .c) :)
